### PR TITLE
Material UIを用いたエリアSelect Bottonの追加

### DIFF
--- a/next-prisma-postgresql/src/app/globals.css
+++ b/next-prisma-postgresql/src/app/globals.css
@@ -7,12 +7,12 @@
   --foreground: #171717;
 }
 
-@media (prefers-color-scheme: dark) {
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
-}
+} */
 
 body {
   color: var(--foreground);

--- a/next-prisma-postgresql/src/app/page.tsx
+++ b/next-prisma-postgresql/src/app/page.tsx
@@ -1,5 +1,6 @@
 import PostForm from "@/components/posts/PostForm";
 import PostList from "@/components/posts/PostList";
+import SelectButton from '@/components/bottons/SelectBotton';
 import { Box } from "@mui/material";
 import { Suspense } from "react";
 import dynamic from 'next/dynamic';
@@ -9,14 +10,16 @@ const LeafletMap = dynamic(() => import('../components/map/LeafletMap'), {
   ssr: false, // サーバーサイドレンダリングを無効化
 });
 
-/// 
+
 export default async function Post() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <div>
-          <h1>カスタムイメージにマーカーを設置</h1>
           <LeafletMap />
+        </div>
+        <div>
+          <SelectButton />
         </div>
         <Box>
           <Suspense fallback={<div>Loading...</div>}>

--- a/next-prisma-postgresql/src/components/bottons/SelectBotton.tsx
+++ b/next-prisma-postgresql/src/components/bottons/SelectBotton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from 'react';
 import { Select, MenuItem, FormControl, InputLabel, SelectChangeEvent } from '@mui/material';
 
@@ -11,20 +13,23 @@ export default function SelectButton() {
 
   return (
     <FormControl fullWidth>
-      <InputLabel id="select-label">選択してください</InputLabel>
+      <InputLabel id="select-label">エリアを選択してください</InputLabel>
       <Select
         labelId="select-label"
         id="select"
         value={selectedValue}
-        label="選択してください"
+        label="エリア選択"
         onChange={handleChange}
       >
         <MenuItem value="">
           <em>None</em>
         </MenuItem>
-        <MenuItem value={10}>Option 1</MenuItem>
-        <MenuItem value={20}>Option 2</MenuItem>
-        <MenuItem value={30}>Option 3</MenuItem>
+        <MenuItem value={10}>新講義棟エリア</MenuItem>
+        <MenuItem value={20}>事務棟エリア</MenuItem>
+        <MenuItem value={30}>図書館棟エリア</MenuItem>
+        <MenuItem value={40}>電気棟エリア</MenuItem>
+        <MenuItem value={50}>屋外ステージエリア</MenuItem>
+        <MenuItem value={60}>機械建設棟エリア</MenuItem>
       </Select>
     </FormControl>
   );

--- a/next-prisma-postgresql/src/components/select-botton.tsx
+++ b/next-prisma-postgresql/src/components/select-botton.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { Select, MenuItem, FormControl, InputLabel, SelectChangeEvent } from '@mui/material';
+
+export default function SelectButton() {
+  const [selectedValue, setSelectedValue] = useState<string>('');
+
+  // SelectChangeEvent 型を使用
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    setSelectedValue(event.target.value);
+  };
+
+  return (
+    <FormControl fullWidth>
+      <InputLabel id="select-label">選択してください</InputLabel>
+      <Select
+        labelId="select-label"
+        id="select"
+        value={selectedValue}
+        label="選択してください"
+        onChange={handleChange}
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        <MenuItem value={10}>Option 1</MenuItem>
+        <MenuItem value={20}>Option 2</MenuItem>
+        <MenuItem value={30}>Option 3</MenuItem>
+      </Select>
+    </FormControl>
+  );
+}


### PR DESCRIPTION
# 実装した機能
Material UIを用いてテキスト入力ユニットの上部にSelect Bottonを追加しました．

# 確認事項
- [ ] npm run buildでビルドできるか
- [ ] 各アイテムを選択した際にテキストがアイテム名になるか